### PR TITLE
Fixed TOC and added collapse markdown section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ this is hidden
 </details>
 ```
 
+Collapsing large blocks of Markdown text
+
+<details>
+<summary>To make sure markdown is rendered correctly in the collapsed section...</summary>
+
+ 1. Put an **empty line** after the `<summary>` block.
+ 2. *Insert your markdown syntax*
+ 3. Put an **empty line** before the `</details>` tag
+ 
+</details>
+
+```
+<details>
+<summary>To make sure markdown is rendered correctly in the collapsed section...</summary>
+
+ 1. Put an **empty line** after the `<summary>` block.
+ 2. *Insert your markdown syntax*
+ 3. Put an **empty line** before the `</details>` tag
+ 
+</details>
+```
+
 ---
 
 ### `additional links`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (TOC:collapse=true&collapseText="Click to expand") -->
 <details>
 <summary>"Click to expand"</summary>
+
 - [Why markdown?](#why-markdown)
 - [Markdown basics](#markdown-basics)
 - [Advanced Formatting tips](#advanced-formatting-tips)
@@ -20,6 +21,7 @@
 - [How Serverless uses markdown](#how-serverless-uses-markdown)
   * [DEMO](#demo)
 - [Other Markdown Resources](#other-markdown-resources)
+
 </details>
 <!-- AUTO-GENERATED-CONTENT:END -->
 


### PR DESCRIPTION
Fixed the rendering issue of the TOC and added an addition within the collapsing section to show people how to format their markdown text correctly within the `<details>` tag